### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 MCP Server for the FluentLab's Funding Assistant API.
 
+<a href="https://glama.ai/mcp/servers/@fundfluent-admin/funding-assistant">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@fundfluent-admin/funding-assistant/badge" alt="FluentLab Funding Assistant MCP server" />
+</a>
+
 ## Tools
 
 1. `get-funding-options`


### PR DESCRIPTION
This PR adds a badge for the [FluentLab Funding Assistant](https://glama.ai/mcp/servers/@fundfluent-admin/funding-assistant) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@fundfluent-admin/funding-assistant">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@fundfluent-admin/funding-assistant/badge" alt="FluentLab Funding Assistant MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.